### PR TITLE
Hand off all arguments supplied to the breaker callback.

### DIFF
--- a/lib/circuitBreaker.js
+++ b/lib/circuitBreaker.js
@@ -115,7 +115,7 @@ function go(cb_wrapped, cb_final) {
 			if (!beenhere) {
 				beenhere = true;
 				self.checkResults(error, self);
-				cb_final(error);
+				cb_final.apply(self, arguments);
 
 			} else {
 				//


### PR DESCRIPTION
@dmuth It would be really helpful if I could have all the supplied arguments from the breaker function handed in to the final function. That's what this code supports. I'm hoping you'll be willing to pull it in and push it up to npm with a minor version nudge!
